### PR TITLE
Use Stimulus for handling flash messages, with turbo_streams support

### DIFF
--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -23,4 +23,8 @@ class AuthenticatedController < ApplicationController
     def set_shop_origin
       @shop_origin = current_shopify_domain
     end
+
+    def turbo_flashes
+      turbo_stream.replace("shopify-app-flash", partial: "layouts/flash_messages.html.erb")
+    end
 end

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -1,0 +1,19 @@
+import { Controller } from "stimulus";
+import { flashNotice, flashError } from "../shopify_app/flash_messages";
+
+export default class extends Controller {
+  connect() {
+    if (!window.app) {
+      return;
+    }
+    const flashData = JSON.parse(this.element.dataset.flash);
+
+    if (flashData.notice) {
+      flashNotice(flashData.notice);
+    }
+
+    if (flashData.error) {
+      flashError(flashData.error);
+    }
+  }
+}

--- a/app/javascript/controllers/flash_controller.js
+++ b/app/javascript/controllers/flash_controller.js
@@ -12,8 +12,8 @@ export default class extends Controller {
       flashNotice(flashData.notice);
     }
 
-    if (flashData.error) {
-      flashError(flashData.error);
+    if (flashData.alert) {
+      flashError(flashData.alert);
     }
   }
 }

--- a/app/javascript/shopify_app/flash_messages.js
+++ b/app/javascript/shopify_app/flash_messages.js
@@ -1,20 +1,4 @@
-import { Toast } from '@shopify/app-bridge/actions';
-
-document.addEventListener("turbo:load", (event) => {
-  if (!window.app) { return }
-
-  const shopifyAppFlash = document.getElementById('shopify-app-flash')
-  if (!shopifyAppFlash) { return }
-  const flashData = JSON.parse(shopifyAppFlash.dataset.flash);
-
-  if (flashData.notice) {
-    flashNotice(flashData.notice);
-  }
-
-  if (flashData.alert) {
-    flashError(flashData.alert);
-  }
-});
+import { Toast } from "@shopify/app-bridge/actions";
 
 export function flashNotice(message) {
   Toast.create(window.app, {

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -1,6 +1,9 @@
-<% content_for :javascript do %>
-  <%= content_tag(:div, nil, id: 'shopify-app-flash', data: { flash: { notice: flash[:notice], alert: flash[:alert] } }) %>
-<% end %>
+<%= content_tag(:div, nil, id: 'shopify-app-flash', data: {
+  controller: "flash",
+  flash: {
+    notice: (flash.now[:notice].presence || flash[:notice]),
+    error: (flash.now[:error].presence || flash[:error]), } }
+  ) %>
 
 <% unless Rails.configuration.force_iframe %>
   <% if notice %>

--- a/app/views/layouts/_flash_messages.html.erb
+++ b/app/views/layouts/_flash_messages.html.erb
@@ -2,8 +2,9 @@
   controller: "flash",
   flash: {
     notice: (flash.now[:notice].presence || flash[:notice]),
-    error: (flash.now[:error].presence || flash[:error]), } }
-  ) %>
+    alert: (flash.now[:alert].presence || flash[:alert]),
+  },
+}) %>
 
 <% unless Rails.configuration.force_iframe %>
   <% if notice %>

--- a/app/views/layouts/_flash_messages.turbo_stream.erb
+++ b/app/views/layouts/_flash_messages.turbo_stream.erb
@@ -1,5 +1,1 @@
-<turbo-stream action="replace" target="shopify-app-flash">
-  <template>
-    <%= render partial: "layouts/flash_messages.html.erb" %>
-  </template>
-</turbo-stream>
+<%= turbo_stream.replace("shopify-app-flash", partial: "layouts/flash_messages.html.erb") %>

--- a/app/views/layouts/_flash_messages.turbo_stream.erb
+++ b/app/views/layouts/_flash_messages.turbo_stream.erb
@@ -1,0 +1,5 @@
+<turbo-stream action="replace" target="shopify-app-flash">
+  <template>
+    <%= render partial: "layouts/flash_messages.html.erb" %>
+  </template>
+</turbo-stream>

--- a/app/views/layouts/embedded_app.turbo_stream.erb
+++ b/app/views/layouts/embedded_app.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%= yield %>
+<%= render partial: "layouts/flash_messages" %>


### PR DESCRIPTION
Adds a `flash_controller.js` for handling flash messages, without relying on turbo events. This now plays nicely with turbo_stream responses as well as normal redirects etc.

Note: The `embedded_app.turbo_stream.erb` layout is automatically used when any authenticated controllers renders a turbo_stream view file. If you are rendering turbo_stream directly inside the controller (without view file) then you'd need to manually render the flash partial, as layout is not used in those cases. 

Examples:

### Automatically renders flash partial

```ruby
  def destroy
    @template = get_template(params[:id])
    @template.destroy
    flash.now[:notice] = "Template deleted!"
    respond_to do |format|
      format.html { redirect_to templates_path }
      format.turbo_stream
    end
  end
```

### When rendering turbo_stream within controller itself, you must manually add turbo_flashes.

```ruby
def some_action
  respond_to do |format|
    format.html
    format.turbo_stream do
      render turbo_stream: turbo_flashes + turbo_stream.replace("x", ...)
    end
  end
end
```