### PR TITLE
Ensure fullpage_redirect_to works with Turbo

### DIFF
--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -27,4 +27,13 @@ class AuthenticatedController < ApplicationController
     def turbo_flashes
       turbo_stream.replace("shopify-app-flash", partial: "layouts/flash_messages.html.erb")
     end
+
+    # Original method in ShopifyApp::LoginProtection
+    def fullpage_redirect_to(url)
+      if ShopifyApp.configuration.embedded_app?
+        render "shared/redirect", status: 303, locals: { url: url }
+      else
+        redirect_to(url)
+      end
+    end
 end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -5,3 +5,6 @@ import { application } from "./application"
 
 import FlashController from "./flash_controller.js"
 application.register("flash", FlashController)
+
+import RedirectController from "./redirect_controller.js"
+application.register("redirect", RedirectController)

--- a/app/javascript/controllers/redirect_controller.js
+++ b/app/javascript/controllers/redirect_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+import { Redirect } from "@shopify/app-bridge/actions";
+
+export default class extends Controller {
+  static values = {
+    url: String
+  }
+
+  connect() {
+    if (!window.app) {
+      return
+    }
+
+    this.appBridgeRedirect(this.urlValue)
+  }
+
+  appBridgeRedirect(url) {
+    const normalizedLink = document.createElement("a");
+    normalizedLink.href = url;
+
+    window.app.dispatch(
+      Redirect.toRemote({
+        url: normalizedLink.href
+      })
+    );
+  }
+}

--- a/app/views/shared/redirect.html.erb
+++ b/app/views/shared/redirect.html.erb
@@ -1,0 +1,6 @@
+<%= content_tag(:div, nil,
+  data: {
+    controller: 'redirect',
+    redirect_url_value: url,
+  }
+) %>


### PR DESCRIPTION
Hi!

After upgrading my app to use Turbo instead of Turbolinks the redirect to a charge (in case a user wants to upgrade their subscription / plan) stopped working.

I was doing this using some inline JS which would be rendered instead of an actual redirect which would call some AppBridge code to perform the redirect. See: https://github.com/Shopify/shopify_app/issues/1287

Because the method `fullpage_redirect_to` relies on Turbolinks I was also not able to use this.

Therefore I came up with the following solution: Render a div which initialises a stimulus redirect controller which then uses the `window.app` (that also contains the `host` param) to dispatch a redirect request.

The code is based on:
- https://shopify.dev/apps/tools/app-bridge/actions#simple-actions
- https://github.com/Shopify/shopify_app/blob/master/app/assets/javascripts/shopify_app/app_bridge_redirect.js