### PR TITLE
Add AppBridge redirect handler to avoid frame reload

### DIFF
--- a/app/javascript/shopify_app/index.js
+++ b/app/javascript/shopify_app/index.js
@@ -1,4 +1,5 @@
 import "./flash_messages"
+import "./navigation"
 import "./request"
 import "./shopify_app"
 import "./url_updater"

--- a/app/javascript/shopify_app/navigation.js
+++ b/app/javascript/shopify_app/navigation.js
@@ -1,0 +1,14 @@
+import { Redirect } from '@shopify/app-bridge/actions'
+
+export function setupRedirectHandler() {
+  app.subscribe(Redirect.Action.APP, (redirectData) => {
+    const urlParams = new URLSearchParams(location.search)
+    const shop = urlParams.get('shop')
+
+    const url = new URL(location.origin + redirectData.path)
+    url.searchParams.set('shop', shop)
+
+    console.log('[shopify_app] Redirecting to:', url.toString())
+    Turbo.visit(url)
+  })
+}

--- a/app/javascript/shopify_app/shopify_app.js
+++ b/app/javascript/shopify_app/shopify_app.js
@@ -1,6 +1,7 @@
 import { Turbo } from "@hotwired/turbo-rails";
 import { getSessionToken } from "@shopify/app-bridge-utils";
 import createApp from '@shopify/app-bridge';
+import { setupRedirectHandler } from './navigation'
 
 document.addEventListener('DOMContentLoaded', () => {
   const shopifyAppInit = document.getElementById('shopify-app-init')
@@ -38,6 +39,8 @@ document.addEventListener('DOMContentLoaded', () => {
       window.jwtExpireAt = jwtExpireAt * 1000;
     }
   });
+
+  setupRedirectHandler()
 });
 
 export async function retrieveToken() {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@hotwired/stimulus": "^3.0.1",
     "@hotwired/turbo-rails": "^7.0.1",
     "@rails/request.js": "^0.0.6",
-    "@shopify/app-bridge-utils": "^2.0.5",
+    "@shopify/app-bridge-utils": "^3.1.1",
     "dotenv": "^10.0.0",
     "esbuild": "^0.14.10",
     "polaris-view-components": "^0.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,17 +30,17 @@
   resolved "https://registry.yarnpkg.com/@rails/request.js/-/request.js-0.0.6.tgz#5f0347a9f363e50ec45118c7134080490cda81d8"
   integrity sha512-dfFWaQXitYJ4kxrgGJNhDNXX54/v10YgoJqBMVe6lhqs6a4N9WD7goZJEvwin82TtK8MqUNhwfyisgKwM6dMdg==
 
-"@shopify/app-bridge-utils@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@shopify/app-bridge-utils/-/app-bridge-utils-2.0.5.tgz#76dc111b28ffa30741484ad69fc9d44086c714dc"
-  integrity sha512-8ngtB1+mUsn2Netrk/Qmy95F7fPjuAHQNPYa0CC5qZ21n66pIE4DN6ykOx8KcOsz8XWoQd8SPnrhU2CWFT9nPw==
+"@shopify/app-bridge-utils@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@shopify/app-bridge-utils/-/app-bridge-utils-3.1.1.tgz#cee566f983b60f96a848998a3ad3b0ba5c7bc4e3"
+  integrity sha512-le1/A62naIj5yq2o/G8htECvYTiAbVzOo9Ue3/gGqlJJC6w7+Uu4ppDHdkg6yfZCmkPUXCIr7+yU3kZHYV5z0g==
   dependencies:
-    "@shopify/app-bridge" "^2.0.5"
+    "@shopify/app-bridge" "^3.1.1"
 
-"@shopify/app-bridge@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@shopify/app-bridge/-/app-bridge-2.0.5.tgz#d669c7a7f008f013457785095268ca6807420d33"
-  integrity sha512-aRQzy+MNRBtxdTcQwG7e2s6tB5UK1T+AiqXvks4x0kOG0TnwOwPpx0JVrY5dipXEEQ3XJkIDTiH6+Kp6LBvHSw==
+"@shopify/app-bridge@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@shopify/app-bridge/-/app-bridge-3.1.1.tgz#40106efb23edf3b209da7f8aae37759e023561ad"
+  integrity sha512-RyjKDFfdytcDu3hcHIjBXvpXKDKMlsvpWshuE5lv5H4WEF+7IQomxmmJSXOJJIYnXv3COIamUml3WP/qVMak5A==
   dependencies:
     base64url "^3.0.1"
 


### PR DESCRIPTION
New handler will help avoiding iframe reloads when using new sidebar navigation: https://shopify.dev/apps/tools/app-bridge/actions/navigation#using-client-side-routing

Make sure to update your AppBridge library to use this feature.