### PR TITLE
Use Turbo "replace" action for splash page visits

### DIFF
--- a/app/javascript/shopify_app/shopify_app.js
+++ b/app/javascript/shopify_app/shopify_app.js
@@ -26,7 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
   })
 
   // Redirect to the requested page
-  Turbo.visit(data.loadPath);
+  Turbo.visit(data.loadPath, { action: "replace" });
 
   document.addEventListener("turbo:load", () => {
     const shopifyAppInit = document.getElementById('shopify-app-init')


### PR DESCRIPTION
To preserve the correct browser history, we should use `{ action: "replace" }` when visiting the load path in `shopify_app.js`, instead of advancing. This ensures the Back button works as expected, instead of always reloading the same (splash) page.

Note: There's still the issue of the initial oauth redirect messing with history, but this get's us one step closer to being able to go back from our app to the original Shopify admin page, after using a deep link.