### PR TITLE
Fix issue of shop=null on some NavigationMenu redirects

### DIFF
--- a/app/javascript/shopify_app/navigation.js
+++ b/app/javascript/shopify_app/navigation.js
@@ -3,7 +3,16 @@ import { Redirect } from '@shopify/app-bridge/actions'
 export function setupRedirectHandler() {
   app.subscribe(Redirect.Action.APP, (redirectData) => {
     const urlParams = new URLSearchParams(location.search)
-    const shop = urlParams.get('shop')
+    let shop = urlParams.get('shop')
+    
+    // workaround for urlParams sometimes missing 'shop'
+    if (shop == null) {
+      const shopifyAppInit = document.getElementById("shopify-app-init");
+      if (!shopifyAppInit) {
+        return;
+      }
+      shop = shopifyAppInit.dataset.shopOrigin;
+    }
 
     const url = new URL(location.origin + redirectData.path)
     url.searchParams.set('shop', shop)


### PR DESCRIPTION
We've been getting reports of people using the new left hand navigation menu, and ending up with an empty screen in the app. The main app page loads fine, but any navigation using the menu causes this. We've tracked it down to the shop param sometimes being missing in `javascript/shopify_app/navigation.js`, and so they end up with `&shop=null`in the final url. This commit adds a fallback method so we grab the myshopify.com from the dom if it's missing in the url params. Could be cleaner, so open to ideas.