### PR TITLE
create host parameter for new unified domain

### DIFF
--- a/app/middleware/app_bridge_middleware.rb
+++ b/app/middleware/app_bridge_middleware.rb
@@ -8,7 +8,12 @@ class AppBridgeMiddleware
 
     if request.params.has_key?("shop") && !request.params.has_key?("host")
       shop = request.params["shop"]
+      if request.url.include?("admin.shopify.com")
+      shop = shop.gsub("myshopify.com", "").gsub("myshopify.io", "")
+      host = Base64.urlsafe_encode64("admin.shopify.com/store/#{shop}", padding: false)
+      else
       host = Base64.urlsafe_encode64("#{shop}/admin", padding: false)
+      end
       request.update_param("host", host)
     end
 


### PR DESCRIPTION
This change updates app middleware to persist host parameter for the [new unified admin.shopify.com domain](https://shopify.dev/apps/tools/app-bridge/getting-started/app-setup#initialize-shopify-app-bridge-in-your-app)