### PR TITLE
Add `x86_64-darwin-22` platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,6 +285,7 @@ PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
   x86_64-darwin-20
+  x86_64-darwin-22
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
### What does this PR include?
Add `x86_64-darwin-22` platform in `Gemfile.lock`