### PR TITLE
Add `x86_64-linux` platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.0-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.0-x86_64-linux)
+      racc (~> 1.4)
     oj (3.13.23)
     openssl (3.1.0)
     pg (1.4.5)
@@ -286,6 +288,7 @@ PLATFORMS
   arm64-darwin-22
   x86_64-darwin-20
   x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
### Motivation / Background
Got the following error when deploying the app on `Heroku-22` stack.
```bash
remote:        Your bundle only supports platforms ["arm64-darwin-20", "arm64-darwin-21",
remote:        "arm64-darwin-22", "x86_64-darwin-20", "x86_64-darwin-22"] but your local
remote:        platform is x86_64-linux. Add the current platform to the lockfile with
remote:        `bundle lock --add-platform x86_64-linux` and try again.
remote:        Bundler Output: Your bundle only supports platforms ["arm64-darwin-20", "arm64-darwin-21",
remote:        "arm64-darwin-22", "x86_64-darwin-20", "x86_64-darwin-22"] but your local
remote:        platform is x86_64-linux. Add the current platform to the lockfile with
remote:        `bundle lock --add-platform x86_64-linux` and try again.
```

### Detail 
This Pull Request adds `x86_64-linux` platform.